### PR TITLE
Boat gvf rebuild

### DIFF
--- a/conf/airframes/UCM/rover_steering.xml
+++ b/conf/airframes/UCM/rover_steering.xml
@@ -44,7 +44,9 @@
       <configure name="USE_MAGNETOMETER" value="0"/>
     </module-->
 
-    <module name="nav"  type="rover_base"/>
+    <module name="nav"  type="rover_base">
+      <define name="ROVER_BASE_SEND_TRAJECTORY" value="FALSE"/>
+    </module>
     <module name="gvf"  type="module"/>
 
     <module name="guidance" type="rover_steering">

--- a/conf/modules/gvf_module.xml
+++ b/conf/modules/gvf_module.xml
@@ -62,6 +62,7 @@ For more details we refer to https://wiki.paparazziuav.org/wiki/Module/guidance_
 
    <header>
      <file name="gvf.h"/>
+     <file name="gvf_low_level_control.h"/>
      <file name="trajectories/gvf_line.h"/>
      <file name="trajectories/gvf_sin.h"/>
      <file name="trajectories/gvf_ellipse.h"/>
@@ -72,6 +73,7 @@ For more details we refer to https://wiki.paparazziuav.org/wiki/Module/guidance_
 
    <makefile firmware="fixedwing">
      <file name="gvf.c"/>
+     <file name="gvf_low_level_control.c"/>
      <file name="trajectories/gvf_line.c"/>
      <file name="trajectories/gvf_sin.c"/>
      <file name="trajectories/gvf_ellipse.c"/>
@@ -80,6 +82,7 @@ For more details we refer to https://wiki.paparazziuav.org/wiki/Module/guidance_
 
    <makefile firmware="rover">
      <file name="gvf.c"/>
+     <file name="gvf_low_level_control.c"/>
      <file name="trajectories/gvf_line.c"/>
      <file name="trajectories/gvf_sin.c"/>
      <file name="trajectories/gvf_ellipse.c"/>

--- a/conf/telemetry/default_rover.xml
+++ b/conf/telemetry/default_rover.xml
@@ -13,6 +13,8 @@
       <message name="ALIVE"                  period="2.1"/>
       <message name="DL_VALUE"               period="1.1"/>
       <message name="ROTORCRAFT_NAV_STATUS"  period="1.6"/>
+      <message name="CIRCLE"                 period=".25"/>
+      <message name="SEGMENT"                period=".25"/>
       <message name="WP_MOVED"               period="1.3"/>
       <message name="GPS_INT"                period=".25"/>
       <message name="INS"                    period=".25"/>

--- a/sw/airborne/firmwares/rover/guidance/boat_guidance.c
+++ b/sw/airborne/firmwares/rover/guidance/boat_guidance.c
@@ -101,16 +101,8 @@ void boat_guidance_read_rc(void){
 /** CTRL functions **/
 void boat_guidance_bearing_GVF_ctrl(void) // TODO: Boat GVF bearing control
 {
-  guidance_control.cmd.gvf_omega = gvf_omega; //GVF give us this omega
+  guidance_control.cmd.omega = gvf_control.omega; //GVF give us this omega
 
-  // Speed is bounded to avoid GPS noise while sailing at small velocity
-  //float speed = BoundSpeed(stateGetHorizontalSpeedNorm_f()); 
-
-  if (fabs(omega)>0.0) {
-      //delta = 
-    }
-
-  //guidance_control.cmd.delta = BoundDelta(delta);
 }
 
 void boat_guidance_bearing_static_ctrl(void){ // TODO: Boat static bearing control

--- a/sw/airborne/firmwares/rover/guidance/boat_guidance.c
+++ b/sw/airborne/firmwares/rover/guidance/boat_guidance.c
@@ -28,6 +28,7 @@
 
 #include "modules/actuators/actuators_default.h"
 #include "modules/radio_control/radio_control.h"
+#include "modules/guidance/gvf/gvf.h"
 #include "autopilot.h"
 #include "navigation.h"
 #include "state.h"
@@ -100,8 +101,7 @@ void boat_guidance_read_rc(void){
 /** CTRL functions **/
 void boat_guidance_bearing_GVF_ctrl(void) // TODO: Boat GVF bearing control
 {
-  //float delta = 0.0;
-  float omega = guidance_control.gvf_omega; //GVF give us this omega
+  guidance_control.cmd.gvf_omega = gvf_omega; //GVF give us this omega
 
   // Speed is bounded to avoid GPS noise while sailing at small velocity
   //float speed = BoundSpeed(stateGetHorizontalSpeedNorm_f()); 

--- a/sw/airborne/firmwares/rover/guidance/boat_guidance.h
+++ b/sw/airborne/firmwares/rover/guidance/boat_guidance.h
@@ -72,7 +72,6 @@ typedef struct {
 // Main structure
 typedef struct {
   guidance_cmd_t cmd;
-  float gvf_omega;
 
   float throttle; //  Td + Ti
   float bearing;  // |Td - Ti|

--- a/sw/airborne/firmwares/rover/guidance/rover_guidance_steering.c
+++ b/sw/airborne/firmwares/rover/guidance/rover_guidance_steering.c
@@ -28,6 +28,7 @@
 
 #include "modules/actuators/actuators_default.h"
 #include "modules/radio_control/radio_control.h"
+#include "modules/guidance/gvf/gvf.h"
 #include "autopilot.h"
 #include "navigation.h"
 #include "state.h"
@@ -71,7 +72,7 @@ void rover_guidance_steering_init(void)
 void rover_guidance_steering_heading_ctrl(void)
 {
   float delta = 0.0;
-  float omega = guidance_control.gvf_omega; //GVF give us this omega
+  float omega = gvf_omega; //GVF give us this omega
 
   // Speed is bounded to avoid GPS noise while driving at small velocity
   float speed = BoundSpeed(stateGetHorizontalSpeedNorm_f()); 

--- a/sw/airborne/firmwares/rover/guidance/rover_guidance_steering.c
+++ b/sw/airborne/firmwares/rover/guidance/rover_guidance_steering.c
@@ -72,7 +72,7 @@ void rover_guidance_steering_init(void)
 void rover_guidance_steering_heading_ctrl(void)
 {
   float delta = 0.0;
-  float omega = gvf_omega; //GVF give us this omega
+  float omega = gvf_control.omega; //GVF give us this omega
 
   // Speed is bounded to avoid GPS noise while driving at small velocity
   float speed = BoundSpeed(stateGetHorizontalSpeedNorm_f()); 

--- a/sw/airborne/firmwares/rover/guidance/rover_guidance_steering.h
+++ b/sw/airborne/firmwares/rover/guidance/rover_guidance_steering.h
@@ -105,7 +105,6 @@ typedef struct {
 // Main structure
 typedef struct {
   sr_cmd_t cmd;
-  float gvf_omega;
   float throttle;
 
   float speed_error;

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -209,6 +209,7 @@ void gvf_control_2D(float ke, float kn, float e,
 
   float omega = omega_d + kn * (mr_x * md_y - mr_y * md_x);
   
+  gvf_control.omega = omega;
   gvf_low_level_control_2D(omega);
 }
 

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -38,6 +38,15 @@
 #define GVF_MODE_WAYPOINT HORIZONTAL_MODE_WAYPOINT
 #define GVF_MODE_CIRCLE HORIZONTAL_MODE_CIRCLE
 
+#elif defined(ROTORCRAFT_FIRMWARE)
+#include "firmwares/rotorcraft/navigation.h"
+#include "modules/nav/common_nav.h"
+#include "firmwares/rotorcraft/stabilization/stabilization_attitude.h"
+#define gvf_setNavMode(_navMode) (horizontal_mode = _navMode)
+#define GVF_MODE_ROUTE HORIZONTAL_MODE_ROUTE
+#define GVF_MODE_WAYPOINT HORIZONTAL_MODE_WAYPOINT
+#define GVF_MODE_CIRCLE HORIZONTAL_MODE_CIRCLE
+
 #elif defined(ROVER_FIRMWARE)
 #include "state.h"
 #include "firmwares/rover/navigation.h"

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -254,9 +254,6 @@ void gvf_control_2D(float ke, float kn, float e,
   
   //TODO: Tengo que modificar el guiado del rover y el barco para elimitar esta condición.
   //      La idea es que estos .c accedan directamente a la variable global gvf_omge.
-  #if defined(ROVER_FIRMWARE) 
-    guidance_control.gvf_omega = omega; 
-  #endif
 
   gvf_omega = omega;
 }

--- a/sw/airborne/modules/guidance/gvf/gvf.c
+++ b/sw/airborne/modules/guidance/gvf/gvf.c
@@ -27,24 +27,34 @@
 #include "modules/guidance/gvf/trajectories/gvf_ellipse.h"
 #include "modules/guidance/gvf/trajectories/gvf_line.h"
 #include "modules/guidance/gvf/trajectories/gvf_sin.h"
+#include "autopilot.h"
 
 #ifdef FIXEDWING_FIRMWARE
 #include "firmwares/fixedwing/nav.h"
 #include "modules/nav/common_nav.h"
 #include "firmwares/fixedwing/stabilization/stabilization_attitude.h"
+#define gvf_setNavMode(_navMode) (horizontal_mode = _navMode)
+#define GVF_MODE_ROUTE HORIZONTAL_MODE_ROUTE
+#define GVF_MODE_WAYPOINT HORIZONTAL_MODE_WAYPOINT
+#define GVF_MODE_CIRCLE HORIZONTAL_MODE_CIRCLE
+
 #elif defined(ROVER_FIRMWARE)
 #include "state.h"
-#include "modules/nav/nav_rover_base.h"
 #include "firmwares/rover/navigation.h"
-struct EnuCoor_f gvf_draw_wp;
+#define gvf_setNavMode(_navMode) (nav.mode = _navMode)
+#define GVF_MODE_ROUTE NAV_MODE_ROUTE
+#define GVF_MODE_WAYPOINT NAV_MODE_WAYPOINT
+#define GVF_MODE_CIRCLE NAV_MODE_CIRCLE
+
 #else
 #error "Firmware not supported by GVF!"
 #endif
 
-#include "autopilot.h"
-
 // Control
 gvf_con gvf_control;
+
+// GVF output variable
+float gvf_omega;
 
 // Trajectory
 gvf_tra gvf_trajectory;
@@ -166,7 +176,7 @@ void gvf_control_2D(float ke, float kn, float e,
 {
   gvf_t0 = get_sys_time_msec();
 
-  #if defined(FIXEDWING_FIRMWARE)
+  #if defined(FIXEDWING_FIRMWARE) || defined(ROTORCRAFT_FIRMWARE)
     float ground_speed = stateGetHorizontalSpeedNorm_f();
     float course = stateGetHorizontalSpeedDir_f();
     float px_dot = ground_speed * sinf(course);
@@ -227,7 +237,7 @@ void gvf_control_2D(float ke, float kn, float e,
 
   float omega = omega_d + kn * (mr_x * md_y - mr_y * md_x);
 
-  #if defined(FIXEDWING_FIRMWARE)
+  #if defined(FIXEDWING_FIRMWARE) || defined(ROTORCRAFT_FIRMWARE)
   if (autopilot_get_mode() == AP_MODE_AUTO2) {
 
     // Coordinated turn
@@ -240,23 +250,21 @@ void gvf_control_2D(float ke, float kn, float e,
       -atanf(omega * ground_speed / GVF_GRAVITY / cosf(att->theta));
     BoundAbs(h_ctl_roll_setpoint, h_ctl_roll_max_setpoint);
   }
-
-  #elif defined(ROVER_FIRMWARE) 
-    guidance_control.gvf_omega = omega; //TODO: set omega into external GVF variable
-
-  #else
-  #error GVF does not support your firmware yet
   #endif
+  
+  //TODO: Tengo que modificar el guiado del rover y el barco para elimitar esta condición.
+  //      La idea es que estos .c accedan directamente a la variable global gvf_omge.
+  #if defined(ROVER_FIRMWARE) 
+    guidance_control.gvf_omega = omega; 
+  #endif
+
+  gvf_omega = omega;
 }
 
 void gvf_set_direction(int8_t s)
 {
   gvf_control.s = s;
 }
-
-
-
-#ifdef FIXEDWING_FIRMWARE // FIXEDWING TRAJECTORIES
 
 // STRAIGHT LINE
 
@@ -277,7 +285,7 @@ static void gvf_line(float a, float b, float heading)
 
   gvf_control.error = e;
   
-  horizontal_mode = HORIZONTAL_MODE_WAYPOINT;
+  gvf_setNavMode(GVF_MODE_WAYPOINT);
   
   gvf_segment.seg = 0;
 }
@@ -296,7 +304,7 @@ bool gvf_line_XY1_XY2(float x1, float y1, float x2, float y2)
 
   gvf_line_XY_heading(x1, y1, atan2f(zx, zy));
   
-  horizontal_mode = HORIZONTAL_MODE_ROUTE;
+  gvf_setNavMode(GVF_MODE_ROUTE);
   gvf_segment.seg = 1;
   gvf_segment.x1 = x1;
   gvf_segment.y1 = y1;
@@ -308,10 +316,10 @@ bool gvf_line_XY1_XY2(float x1, float y1, float x2, float y2)
 
 bool gvf_line_wp1_wp2(uint8_t wp1, uint8_t wp2)
 {
-  float x1 = waypoints[wp1].x;
-  float y1 = waypoints[wp1].y;
-  float x2 = waypoints[wp2].x;
-  float y2 = waypoints[wp2].y;
+  float x1 = WaypointX(wp1);
+  float y1 = WaypointY(wp1);
+  float x2 = WaypointX(wp2);
+  float y2 = WaypointY(wp2);
 
   return gvf_line_XY1_XY2(x1, y1, x2, y2);
 }
@@ -329,7 +337,7 @@ bool gvf_segment_loop_XY1_XY2(float x1, float y1, float x2, float y2, float d1, 
 
   gvf_line(x1, y1, alpha);
 
-  horizontal_mode = HORIZONTAL_MODE_ROUTE;
+  gvf_setNavMode(GVF_MODE_ROUTE);
   
   gvf_segment.seg = 1;
   gvf_segment.x1 = x1;
@@ -342,10 +350,10 @@ bool gvf_segment_loop_XY1_XY2(float x1, float y1, float x2, float y2, float d1, 
 
 bool gvf_segment_loop_wp1_wp2(uint8_t wp1, uint8_t wp2, float d1, float d2)
 {
-  float x1 = waypoints[wp1].x;
-  float y1 = waypoints[wp1].y;
-  float x2 = waypoints[wp2].x;
-  float y2 = waypoints[wp2].y;
+  float x1 = WaypointX(wp1);
+  float y1 = WaypointY(wp1);
+  float x2 = WaypointX(wp2);
+  float y2 = WaypointY(wp2);
 
   return gvf_segment_loop_XY1_XY2(x1, y1, x2, y2, d1, d2);
 }
@@ -374,10 +382,10 @@ bool gvf_segment_XY1_XY2(float x1, float y1, float x2, float y2)
 
 bool gvf_segment_wp1_wp2(uint8_t wp1, uint8_t wp2)
 {
-  float x1 = waypoints[wp1].x;
-  float y1 = waypoints[wp1].y;
-  float x2 = waypoints[wp2].x;
-  float y2 = waypoints[wp2].y;
+  float x1 = WaypointX(wp1);
+  float y1 = WaypointY(wp1);
+  float x2 = WaypointX(wp2);
+  float y2 = WaypointY(wp2);
 
   return gvf_segment_XY1_XY2(x1, y1, x2, y2);
 }
@@ -386,8 +394,8 @@ bool gvf_line_wp_heading(uint8_t wp, float heading)
 {
   heading = RadOfDeg(heading);
 
-  float a = waypoints[wp].x;
-  float b = waypoints[wp].y;
+  float a = WaypointX(wp);
+  float b = WaypointY(wp);
 
   return gvf_line_XY_heading(a, b, heading);
 }
@@ -414,10 +422,10 @@ bool gvf_ellipse_XY(float x, float y, float a, float b, float alpha)
   }
 
   if ((int)gvf_trajectory.p[2] == (int)gvf_trajectory.p[3]) {
-    horizontal_mode = HORIZONTAL_MODE_CIRCLE;
+    gvf_setNavMode(GVF_MODE_CIRCLE);
 
   } else {
-    horizontal_mode = HORIZONTAL_MODE_WAYPOINT;
+    gvf_setNavMode(GVF_MODE_WAYPOINT);
   }
 
   gvf_ellipse_info(&e, &grad_ellipse, &Hess_ellipse);
@@ -432,8 +440,8 @@ bool gvf_ellipse_XY(float x, float y, float a, float b, float alpha)
 
 
 bool gvf_ellipse_wp(uint8_t wp, float a, float b, float alpha)
-{
-  gvf_ellipse_XY(waypoints[wp].x,  waypoints[wp].y, a, b, alpha);
+{  
+  gvf_ellipse_XY(WaypointX(wp),  WaypointY(wp), a, b, alpha);
   return true;
 }
 
@@ -466,10 +474,10 @@ bool gvf_sin_wp1_wp2(uint8_t wp1, uint8_t wp2, float w, float off, float A)
 {
   w = 2 * M_PI * w;
 
-  float x1 = waypoints[wp1].x;
-  float y1 = waypoints[wp1].y;
-  float x2 = waypoints[wp2].x;
-  float y2 = waypoints[wp2].y;
+  float x1 = WaypointX(wp1);
+  float y1 = WaypointY(wp1);
+  float x2 = WaypointX(wp2);
+  float y2 = WaypointY(wp2);
 
   float zx = x1 - x2;
   float zy = y1 - y2;
@@ -486,267 +494,11 @@ bool gvf_sin_wp_alpha(uint8_t wp, float alpha, float w, float off, float A)
   w = 2 * M_PI * w;
   alpha = RadOfDeg(alpha);
 
-  float x = waypoints[wp].x;
-  float y = waypoints[wp].y;
+  float x = WaypointX(wp);
+  float y = WaypointY(wp);
 
   gvf_sin_XY_alpha(x, y, alpha, w, off, A);
 
   return true;
 }
-
-
-#elif defined(ROVER_FIRMWARE) // ROVER TRAJECTORIES
-
-// STRAIGHT LINE
-
-static void gvf_line(float a, float b, float heading)
-{
-  float e;
-  struct gvf_grad grad_line;
-  struct gvf_Hess Hess_line;
-
-  gvf_trajectory.type = 0;
-  gvf_trajectory.p[0] = a;
-  gvf_trajectory.p[1] = b;
-  gvf_trajectory.p[2] = heading;
-
-  gvf_line_info(&e, &grad_line, &Hess_line);
-  gvf_control.ke = gvf_line_par.ke;
-  gvf_control_2D(1e-2 * gvf_line_par.ke, gvf_line_par.kn, e, &grad_line, &Hess_line);
-
-  gvf_control.error = e;
-  
-  nav.mode = NAV_MODE_WAYPOINT;
-  
-  gvf_segment.seg = 0;
-}
-
-bool gvf_line_XY_heading(float a, float b, float heading)
-{
-  gvf_set_direction(1);
-  gvf_line(a, b, heading);
-  return true;
-}
-
-bool gvf_line_XY1_XY2(float x1, float y1, float x2, float y2)
-{
-  float zx = x2 - x1;
-  float zy = y2 - y1;
-
-  gvf_line_XY_heading(x1, y1, atan2f(zx, zy));
-  
-  nav.mode = NAV_MODE_ROUTE;
-  
-  gvf_segment.seg = 1;
-  gvf_segment.x1 = x1;
-  gvf_segment.y1 = y1;
-  gvf_segment.x2 = x2;
-  gvf_segment.y2 = y2;
-
-  // Send rover_base navigation data to draw segment (ROUTE)
-  nav_rover_base.goto_wp.from.x = x1;
-  nav_rover_base.goto_wp.from.y = y1;
-  nav_rover_base.goto_wp.to.x = x2;
-  nav_rover_base.goto_wp.to.y = y2;
-
-  return true;
-}
-
-bool gvf_line_wp1_wp2(uint8_t wp1, uint8_t wp2)
-{
-  float x1 = waypoint_get_x(wp1);
-  float y1 = waypoint_get_y(wp1);
-  float x2 = waypoint_get_x(wp2);
-  float y2 = waypoint_get_y(wp2);
-
-  return gvf_line_XY1_XY2(x1, y1, x2, y2);
-}
-
-bool gvf_segment_loop_XY1_XY2(float x1, float y1, float x2, float y2, float d1, float d2)
-{
-  int s = out_of_segment_area(x1, y1, x2, y2, d1, d2);
-  if (s != 0) {
-    gvf_control.s = s;
-  }
-
-  float zx = x2 - x1;
-  float zy = y2 - y1;
-  float alpha = atanf(zx / zy);
-
-  gvf_line(x1, y1, alpha);
-
-  nav.mode = NAV_MODE_ROUTE;
-  
-  gvf_segment.seg = 1;
-  gvf_segment.x1 = x1;
-  gvf_segment.y1 = y1;
-  gvf_segment.x2 = x2;
-  gvf_segment.y2 = y2;
-
-  // Send rover_base navigation data to draw segment (ROUTE)
-  nav_rover_base.goto_wp.from.x = x1;
-  nav_rover_base.goto_wp.from.y = y1;
-  nav_rover_base.goto_wp.to.x = x2;
-  nav_rover_base.goto_wp.to.y = y2;
-
-  return true;
-}
-
-bool gvf_segment_loop_wp1_wp2(uint8_t wp1, uint8_t wp2, float d1, float d2)
-{
-  float x1 = waypoint_get_x(wp1);
-  float y1 = waypoint_get_y(wp1);
-  float x2 = waypoint_get_x(wp2);
-  float y2 = waypoint_get_y(wp2);
-
-  return gvf_segment_loop_XY1_XY2(x1, y1, x2, y2, d1, d2);
-}
-
-bool gvf_segment_XY1_XY2(float x1, float y1, float x2, float y2)
-{
-  struct EnuCoor_f *p = stateGetPositionEnu_f();
-  float px = p->x - x1;
-  float py = p->y - y1;
-
-  float zx = x2 - x1;
-  float zy = y2 - y1;
-
-  float beta = atan2f(zy, zx);
-  float cosb = cosf(-beta);
-  float sinb = sinf(-beta);
-  float zxr = zx * cosb - zy * sinb;
-  float pxr = px * cosb - py * sinb;
-
-  if ((zxr > 0 && pxr > zxr) || (zxr < 0 && pxr < zxr)) {
-    return false;
-  }
-
-  return gvf_line_XY1_XY2(x1, y1, x2, y2);
-}
-
-bool gvf_segment_wp1_wp2(uint8_t wp1, uint8_t wp2)
-{
-  float x1 = waypoint_get_x(wp1);
-  float y1 = waypoint_get_y(wp1);
-  float x2 = waypoint_get_x(wp2);
-  float y2 = waypoint_get_y(wp2);
-
-  return gvf_segment_XY1_XY2(x1, y1, x2, y2);
-}
-
-bool gvf_line_wp_heading(uint8_t wp, float heading)
-{
-  heading = RadOfDeg(heading);
-
-  float a = waypoint_get_x(wp);
-  float b = waypoint_get_y(wp);
-
-  return gvf_line_XY_heading(a, b, heading);
-}
-
-// ELLIPSE
-
-bool gvf_ellipse_XY(float x, float y, float a, float b, float alpha)
-{
-  float e;
-  struct gvf_grad grad_ellipse;
-  struct gvf_Hess Hess_ellipse;
-
-  gvf_trajectory.type = 1;
-  gvf_trajectory.p[0] = x;
-  gvf_trajectory.p[1] = y;
-  gvf_trajectory.p[2] = a;
-  gvf_trajectory.p[3] = b;
-  gvf_trajectory.p[4] = alpha;
-
-  // SAFE MODE
-  if (a < 1 || b < 1) {
-    gvf_trajectory.p[2] = 60;
-    gvf_trajectory.p[3] = 60;
-  }
-
-  // Send rover_base navigation data to draw circle (CIRCLE)
-  if (gvf_trajectory.p[2] == gvf_trajectory.p[3]) {
-    nav.mode = NAV_MODE_CIRCLE;
-    nav_rover_base.circle.center.x = x;
-    nav_rover_base.circle.center.y = y;
-    nav_rover_base.circle.radius = a;
-  } else {
-    nav.mode = NAV_MODE_WAYPOINT;
-  }
-
-  gvf_ellipse_info(&e, &grad_ellipse, &Hess_ellipse);
-  gvf_control.ke = gvf_ellipse_par.ke;
-  gvf_control_2D(gvf_ellipse_par.ke, gvf_ellipse_par.kn,
-                 e, &grad_ellipse, &Hess_ellipse);
-
-  gvf_control.error = e;
-
-  return true;
-}
-
-
-bool gvf_ellipse_wp(uint8_t wp, float a, float b, float alpha)
-{
-  gvf_ellipse_XY(waypoint_get_x(wp),  waypoint_get_y(wp), a, b, alpha);
-  return true;
-}
-
-// SINUSOIDAL (if w = 0 and off = 0, then we just have the straight line case)
-
-bool gvf_sin_XY_alpha(float a, float b, float alpha, float w, float off, float A)
-{
-  float e;
-  struct gvf_grad grad_line;
-  struct gvf_Hess Hess_line;
-
-  gvf_trajectory.type = 2;
-  gvf_trajectory.p[0] = a;
-  gvf_trajectory.p[1] = b;
-  gvf_trajectory.p[2] = alpha;
-  gvf_trajectory.p[3] = w;
-  gvf_trajectory.p[4] = off;
-  gvf_trajectory.p[5] = A;
-
-  gvf_sin_info(&e, &grad_line, &Hess_line);
-  gvf_control.ke = gvf_sin_par.ke;
-  gvf_control_2D(1e-2 * gvf_sin_par.ke, gvf_sin_par.kn, e, &grad_line, &Hess_line);
-
-  gvf_control.error = e;
-
-  return true;
-}
-
-bool gvf_sin_wp1_wp2(uint8_t wp1, uint8_t wp2, float w, float off, float A)
-{
-  w = 2 * M_PI * w;
-
-  float x1 = waypoint_get_x(wp1);
-  float y1 = waypoint_get_y(wp1);
-  float x2 = waypoint_get_x(wp2);
-  float y2 = waypoint_get_y(wp2);
-
-  float zx = x1 - x2;
-  float zy = y1 - y2;
-
-  float alpha = atanf(zy / zx);
-
-  gvf_sin_XY_alpha(x1, y1, alpha, w, off, A);
-
-  return true;
-}
-
-bool gvf_sin_wp_alpha(uint8_t wp, float alpha, float w, float off, float A)
-{
-  w = 2 * M_PI * w;
-  alpha = RadOfDeg(alpha);
-
-  float x = waypoint_get_x(wp);
-  float y = waypoint_get_y(wp);
-
-  gvf_sin_XY_alpha(x, y, alpha, w, off, A);
-
-  return true;
-}
-#endif
 

--- a/sw/airborne/modules/guidance/gvf/gvf.h
+++ b/sw/airborne/modules/guidance/gvf/gvf.h
@@ -43,11 +43,19 @@ typedef struct {
   float ke;
   float kn;
   float error;
+  float omega;
   int8_t s;
 } gvf_con;
 
 extern gvf_con gvf_control;
-extern float gvf_omega;
+
+typedef struct {
+  float course;
+  float px_dot;
+  float py_dot;
+} gvf_st;
+
+extern gvf_st gvf_state;
 
 enum trajectories {
   LINE = 0,

--- a/sw/airborne/modules/guidance/gvf/gvf.h
+++ b/sw/airborne/modules/guidance/gvf/gvf.h
@@ -47,6 +47,7 @@ typedef struct {
 } gvf_con;
 
 extern gvf_con gvf_control;
+extern float gvf_omega;
 
 enum trajectories {
   LINE = 0,

--- a/sw/airborne/modules/guidance/gvf/gvf_low_level_control.c
+++ b/sw/airborne/modules/guidance/gvf/gvf_low_level_control.c
@@ -51,8 +51,6 @@ void gvf_low_level_getState(void)
 
 void gvf_low_level_control_2D(float omega)
 {
-
-  gvf_control.omega = omega;
   
 #if defined(FIXEDWING_FIRMWARE)
   if (autopilot_get_mode() == AP_MODE_AUTO2) {

--- a/sw/airborne/modules/guidance/gvf/gvf_low_level_control.c
+++ b/sw/airborne/modules/guidance/gvf/gvf_low_level_control.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Hector Garcia de Marina <hgarciad@ucm.es>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/guidance/gvf/gvf_low_level_control.c
+ *
+ * Firmware dependent file for the guiding vector field algorithm for 2D trajectories.
+ */
+
+#include "autopilot.h"
+#include "modules/guidance/gvf/gvf_low_level_control.h"
+#include "modules/guidance/gvf/gvf.h"
+
+#if defined(FIXEDWING_FIRMWARE)
+#include "firmwares/fixedwing/stabilization/stabilization_attitude.h"
+#endif
+
+void gvf_low_level_getState(void)
+{
+  #if defined(FIXEDWING_FIRMWARE)
+    float ground_speed = stateGetHorizontalSpeedNorm_f();
+    gvf_state.course = stateGetHorizontalSpeedDir_f();
+    gvf_state.px_dot = ground_speed * sinf(course);
+    gvf_state.py_dot = ground_speed * cosf(course);
+    
+  #elif defined(ROVER_FIRMWARE)
+    // We assume that the course and psi
+    // of the rover (steering wheel) are the same
+    gvf_state.course = stateGetNedToBodyEulers_f()->psi;
+    gvf_state.px_dot = stateGetSpeedEnu_f()->x;
+    gvf_state.py_dot = stateGetSpeedEnu_f()->y;
+  #endif
+}
+
+void gvf_low_level_control_2D(float omega)
+{
+
+  gvf_control.omega = omega;
+  
+#if defined(FIXEDWING_FIRMWARE)
+  if (autopilot_get_mode() == AP_MODE_AUTO2) {
+
+    // Coordinated turn
+    struct FloatEulers *att = stateGetNedToBodyEulers_f();
+    float ground_speed = stateGetHorizontalSpeedNorm_f();
+
+    lateral_mode = LATERAL_MODE_ROLL;
+
+    h_ctl_roll_setpoint =
+      -atanf(omega * ground_speed / GVF_GRAVITY / cosf(att->theta));
+    BoundAbs(h_ctl_roll_setpoint, h_ctl_roll_max_setpoint);
+  }
+#endif
+
+}
+

--- a/sw/airborne/modules/guidance/gvf/gvf_low_level_control.h
+++ b/sw/airborne/modules/guidance/gvf/gvf_low_level_control.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Hector Garcia de Marina <hgarciad@ucm.es>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file modules/guidance/gvf/gvf_low_level_control.h
+ *
+ * Firmware dependent file for the guiding vector field algorithm for 2D trajectories.
+ */
+
+#ifndef GVF_LOW_LEVEL_CONTROL_H
+#define GVF_LOW_LEVEL_CONTROL_H
+
+#ifdef FIXEDWING_FIRMWARE
+#include "firmwares/fixedwing/nav.h"
+#include "modules/nav/common_nav.h"
+#include "firmwares/fixedwing/stabilization/stabilization_attitude.h"
+#define gvf_setNavMode(_navMode) (horizontal_mode = _navMode)
+#define GVF_MODE_ROUTE HORIZONTAL_MODE_ROUTE
+#define GVF_MODE_WAYPOINT HORIZONTAL_MODE_WAYPOINT
+#define GVF_MODE_CIRCLE HORIZONTAL_MODE_CIRCLE
+
+#elif defined(ROVER_FIRMWARE)
+#include "state.h"
+#include "firmwares/rover/navigation.h"
+#define gvf_setNavMode(_navMode) (nav.mode = _navMode)
+#define GVF_MODE_ROUTE NAV_MODE_ROUTE
+#define GVF_MODE_WAYPOINT NAV_MODE_WAYPOINT
+#define GVF_MODE_CIRCLE NAV_MODE_CIRCLE
+
+#else
+#error "GVF does not support your firmware yet!"
+#endif
+
+// Low level control functions
+extern void gvf_low_level_getState(void);
+extern void gvf_low_level_control_2D(float);
+
+#endif // GVF_LOW_LEVEL_CONTROL_H
+

--- a/sw/airborne/modules/nav/nav_rover_base.c
+++ b/sw/airborne/modules/nav/nav_rover_base.c
@@ -248,6 +248,7 @@ static void nav_oval(struct EnuCoor_f *wp1, struct EnuCoor_f *wp2, float radius)
 #if PERIODIC_TELEMETRY
 #include "modules/datalink/telemetry.h"
 
+#if ROVER_BASE_SEND_TRAJECTORY
 static void send_segment(struct transport_tx *trans, struct link_device *dev)
 {
   pprz_msg_send_SEGMENT(trans, dev, AC_ID,
@@ -264,6 +265,7 @@ static void send_circle(struct transport_tx *trans, struct link_device *dev)
       &nav_rover_base.circle.center.y,
       &nav_rover_base.circle.radius);
 }
+#endif // ROVER_BASE_SEND_TRAJECTORY
 
 static void send_nav_status(struct transport_tx *trans, struct link_device *dev)
 {
@@ -274,11 +276,13 @@ static void send_nav_status(struct transport_tx *trans, struct link_device *dev)
                                       &dist_home, &dist_wp,
                                       &nav_block, &nav_stage,
                                       &nav.mode);
+#if ROVER_BASE_SEND_TRAJECTORY                                   
   if (nav.mode == NAV_MODE_ROUTE) {
     send_segment(trans, dev);
   } else if (nav.mode == NAV_MODE_CIRCLE) {
     send_circle(trans, dev);
   }
+#endif // ROVER_BASE_SEND_TRAJECTORY
 }
 #endif
 

--- a/sw/airborne/modules/nav/nav_rover_base.h
+++ b/sw/airborne/modules/nav/nav_rover_base.h
@@ -29,6 +29,10 @@
 
 #include "firmwares/rover/navigation.h"
 
+#ifndef ROVER_BASE_SEND_TRAJECTORY
+#define ROVER_BASE_SEND_TRAJECTORY TRUE
+#endif
+
 /** Waypoint and route pattern
  */
 struct RoverNavGoto {


### PR DESCRIPTION
Reconstrucción de GVF:
- Adaptación de gvf.c para todo tipo de firmwares (solucionado problema con waypoints y modos de navegación).
- Todas las excepciones relacionadas con el firmware ahora están en gvf_low_level_control.
- Añadida variable externa gvf_control.omega para que otros módulos de guiado puedan acceder a ella. Así no se tiene que hacer directacmente la asignación desde GVF. 

Condición de compilación de nav_rover_base:
- Los mensajes  SEGMENT y CIRCLE únicamente se mandarán cuando la variable ROVER_BASE_SEND_TRAJECTORY no se defina como FALSE.

PRECAUCION: La telemetría de GVF es periódica, si no se define una frecuencia en el .xml de configuración de la telemetría no se actualizará el mensaje. Por lo tanto, GCS no recibirá la información necesario para pintar el círculo o segmento.